### PR TITLE
Amend /run tmpfs mount options.

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .env
     tmpfs:
       - /tmp
-      - /run
+      - /run:exec
     volumes:
       - ./pbsconfig/:/root/.config/proxmox-backup/
       # Note - if you want to restore backups make sure to change to read write below.


### PR DESCRIPTION
Ensure /run is executable for S6 on host OSes with different tmpfs mount default options. (i.e. default=noexec).

This appears to affect Alpine/Arch based OSes.

Resolved https://github.com/Aterfax/pbs-client-docker/issues/6#issuecomment-2505701914