### PR TITLE
Add UNENCRYPTED environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ For more in depth instructions, see: [Using-the-DockerHub-provided-image](#Using
 
 ### Using the DockerHub provided image
 
+> [!WARNING]  
+> It is possible, but highly discouraged for you to make unencrypted backups by setting `UNENCRYPTED=1` in your ``.env`` file. This will bypass the automatic key generation process but **this is a bad idea** as the backed-up data will be stored in plaintext. This means that the owner of the PBS backup server you are backing up to will have full access to explore the backed-up content.
+
 * Run the image with the provided docker-compose file after amending it and the ``.env`` file where needed.
   * If allowing the container to conduct an auto setup, don't set a  ``PBS_ENCRYPTION_PASSWORD`` value yet as the container first run will autogenerate one for you.
   * Supply your desired ``master-public.pem``, ``master-private.pem`` and ``encryption-key.json`` files with a matching ``PBS_ENCRYPTION_PASSWORD`` or allow the container to automatically generate these for you on first run.
@@ -96,6 +99,11 @@ To bypass this issue you can manually create some keys or run the container on a
 See also:
 - https://github.com/Aterfax/pbs-client-docker/issues/8
 - https://forum.proxmox.com/threads/backup-client-encryption-not-working-inside-docker-container.139054/
+
+> [!WARNING]  
+> It is possible, but highly discouraged for you to bypass this issue by taking unencrypted backups. You can do this by setting `UNENCRYPTED=1` in your ``.env`` file and this will bypass the automatic key generation process.
+>
+>**This is a bad idea** as the backed-up data will be stored in plaintext. This means that the owner of the PBS backup server you are backing up to will have full access to explore the backed-up content.
 
 ## Troubleshooting
 

--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -6,7 +6,9 @@ CRON_SCHEDULE="0 */4 * * *"
 # If you want to skip backup on startup, set CRON_BACKUP_ONLY=1 otherwise CRON_BACKUP_ONLY=0
 CRON_BACKUP_ONLY=0
 
-# Set UNENCRYPTED=1 to bypass key generation and allow the backup to be unencrypted
+# Set UNENCRYPTED=1 to bypass automatic encryption key generation and allow the backups to be unencrypted.
+# This is a bad idea as the owner of the PBS backup server you are backing up to will have full access to 
+# explore the backed-up content.
 UNENCRYPTED=0
 
 # Use of the PBS_API_KEY_NAME and PBS_API_KEY_SECRET is recommended!

--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -6,6 +6,9 @@ CRON_SCHEDULE="0 */4 * * *"
 # If you want to skip backup on startup, set CRON_BACKUP_ONLY=1 otherwise CRON_BACKUP_ONLY=0
 CRON_BACKUP_ONLY=0
 
+# Set UNENCRYPTED=1 to bypass key generation and allow the backup to be unencrypted
+UNENCRYPTED=0
+
 # Use of the PBS_API_KEY_NAME and PBS_API_KEY_SECRET is recommended!
 # If unset, ensure PBS_USER and PBS_PASSWORD are set.
 PBS_API_KEY_NAME="username@pam!test"

--- a/docker/src/s6-services/key_setup/run
+++ b/docker/src/s6-services/key_setup/run
@@ -23,6 +23,8 @@ trap handle_error ERR
 # Check if encryption is disabled via environment variable
 if [ "${UNENCRYPTED}" = "1" ]; then
     echo "Encrypted backups are disabled. Skipping key setup process."
+    echo ""
+    echo "This is a bad idea as the owner of the PBS backup server you are backing up to will have full access to explore the backed-up content."
     exit 0
 fi
 

--- a/docker/src/s6-services/key_setup/run
+++ b/docker/src/s6-services/key_setup/run
@@ -20,6 +20,12 @@ handle_error() {
 }
 trap handle_error ERR
 
+# Check if encryption is disabled via environment variable
+if [ "${UNENCRYPTED}" = "1" ]; then
+    echo "Encrypted backups are disabled. Skipping key setup process."
+    exit 0
+fi
+
 client_encryption_keyfile="/root/.config/proxmox-backup/encryption-key.json"
 master_private_keyfile="/root/.config/proxmox-backup/master-private.pem"
 master_public_keyfile="/root/.config/proxmox-backup/master-public.pem"


### PR DESCRIPTION
### Add **UNENCRYPTED** Environment Variable

This change pretty self-explanatory. 

By setting **UNENCRYPTED=1** in your environment variables, it _bypass the key generation process_ and allows you to backup _without_ encryption enabled. 

Fully regression tested with live instance of PBS.