### PR TITLE
Read secrets from file

### DIFF
--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -21,6 +21,11 @@ PBS_API_KEY_SECRET=4054356a-f1a6-441e-86fc-e338367db185
 PBS_USER=
 PBS_PASSWORD=
 
+# You can set these two variables to read the necessary secrets from a file if you use e.g. docker secrets.
+# The two environment variables PBS_API_KEY_SECRET and PBS_PASSWORD still have priority
+PBS_API_KEY_SECRET_FILE=
+PBS_PASSWORD_FILE=
+
 # PBS_DATASTORE_NS is optional but should be set if using namespaces.
 PBS_DATASTORE_NS=test
 

--- a/docker/src/s6-services/setup_check/run_include
+++ b/docker/src/s6-services/setup_check/run_include
@@ -1,6 +1,23 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# Read secrets from file. Allow override with ENV.
+if [[ -n "$PBS_API_KEY_SECRET_FILE" && -z "$PBS_API_KEY_SECRET" ]]; then
+    if [ -f "${PBS_API_KEY_SECRET_FILE}" ]; then
+        PBS_PASSWORD=$(cat "${PBS_API_KEY_SECRET_FILE}")
+    else
+        echo "WARNING: PBS_API_KEY_SECRET_FILE is set but the file \"${PBS_API_KEY_SECRET_FILE}\" does not exist"
+    fi
+fi
+
+if [[ -n "$PBS_PASSWORD_FILE" && -z "$PBS_PASSWORD" ]]; then
+    if [ -f "${PBS_PASSWORD_FILE}" ]; then
+        PBS_PASSWORD=$(cat "${PBS_PASSWORD_FILE}")
+    else
+        echo "WARNING: PBS_PASSWORD_FILE is set but the file \"${PBS_PASSWORD_FILE}\" does not exist"
+    fi
+fi
+
 # If an API key is set we should use it over any password / username.
 if [ -n "$PBS_API_KEY_SECRET" ]; then
     PBS_PASSWORD="${PBS_API_KEY_SECRET}"
@@ -26,7 +43,7 @@ if [ -z "$PBS_DATASTORE" ]; then
 fi
 
 if [ -z "$PBS_PASSWORD" ]; then
-    echo "Error: PBS_PASSWORD is not set. This variable is required, please ensure it is set, or set PBS_API_KEY_SECRET."
+    echo "Error: PBS_PASSWORD is not set. This variable is required, please ensure it is set, or set one of PBS_API_KEY_SECRET | PBS_PASSWORD_FILE | PBS_API_KEY_SECRET_FILE."
     exit 1
 fi
 


### PR DESCRIPTION
This adds the environment variables PBS_PASSWORD_FILE and PBS_API_KEY_SECRET_FILE and the logic for reading secrets from files, but prioritizes any environment variables that may be set.
It can be helpful if someone (like me) uses Docker Swarm with GitOps Deployment and wants to keep the secrets in Docker Secrets instead of pushing them to git.