### PR TITLE
Update to support Healthchecks.io instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ For more in depth instructions, see: [Using-the-DockerHub-provided-image](#Using
 > [!WARNING]  
 > It is possible, but highly discouraged for you to make unencrypted backups by setting `UNENCRYPTED=1` in your ``.env`` file. This will bypass the automatic key generation process but **this is a bad idea** as the backed-up data will be stored in plaintext. This means that the owner of the PBS backup server you are backing up to will have full access to explore the backed-up content.
 
+> [!NOTE]  
+> If you use the central Healthchecks.io instance you must the ``.env`` variable ``HEALTHCHECKS_SELF_HOSTED=false`` or checks will not work.
+
+
 * Run the image with the provided docker-compose file after amending it and the ``.env`` file where needed.
   * If allowing the container to conduct an auto setup, don't set a  ``PBS_ENCRYPTION_PASSWORD`` value yet as the container first run will autogenerate one for you.
   * Supply your desired ``master-public.pem``, ``master-private.pem`` and ``encryption-key.json`` files with a matching ``PBS_ENCRYPTION_PASSWORD`` or allow the container to automatically generate these for you on first run.
@@ -89,6 +93,10 @@ The following environment variables can be configured to customize the behavior 
 
 
 ## FAQ
+
+### I'm using the central Healthchecks.io instance and checks are not working
+
+If you use the central Healthchecks.io instance you must the ``.env`` variable ``HEALTHCHECKS_SELF_HOSTED=false`` or checks will not work due to the additional URL subdirectory (``/ping``) used by self hosted instances.
 
 ### Error: Function not implemented (os error 38)
 

--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -38,8 +38,19 @@ PBS_DATASTORE_NS=test
 PBS_BACKUP_CMD_APPEND_EXTRA_OPTS=
 PBS_RESTORE_CMD_APPEND_EXTRA_OPTS=
 
-# Healthchecks.io details - Optional. 
+####### Healthchecks.io details - Optional. #######
 HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
 HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
+HEALTHCHECKS_SELF_HOSTED=true # Defaults true if unset. If you use the central Healthchecks.io instance you must set this to false
+#
+# If you require a custom sub directory ping path you can set it with this HEALTHCHECKS_PING_ENDPOINT_DIR variable.
+# Note: You must also set HEALTHCHECKS_SELF_HOSTED=true for this to be respected.
+#
+# HEALTHCHECKS_PING_ENDPOINT_DIR=ping # Defaults to 'ping' if unset.
+#
+# Note this will concatenate as:
+# HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
+#
+####### Healthchecks.io details - Optional. #######
 
 TZ=Etc/UTC

--- a/docker/src/s6-services/setup_check/run_include
+++ b/docker/src/s6-services/setup_check/run_include
@@ -30,10 +30,24 @@ if [ -z "$PBS_PASSWORD" ]; then
     exit 1
 fi
 
-# Evaluate each subvariable and replace all spaces with nothing - if not zero length set variable.
-if [[ ! -z "${HEALTHCHECKSHOSTNAME// }" ]] && [[ ! -z "${HEALTHCHECKSUUID// }" ]]; then
-  HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/ping/${HEALTHCHECKSUUID}"
-  export HEALTHCHECKSURL="${HEALTHCHECKSURL}"
+# Default to self-hosted if variable is unset
+HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.
+
+# Set the ping subdirectory for self-hosted instances only
+if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
+    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
+else
+    PING_SUBDIR=""
+fi
+
+# Construct Healthchecks URL if required variables are set
+if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
+    if [[ -n "$PING_SUBDIR" ]]; then
+        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
+    else
+        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
+    fi
+    export HEALTHCHECKSURL
 fi
 
 export PBS_PASSWORD="${PBS_PASSWORD}"


### PR DESCRIPTION
Closes https://github.com/Aterfax/pbs-client-docker/issues/25 .

Amends:

- ``README.md``.
- docker-compose ``.env`` example.
- ``run_include`` logic refactor.

# Validations:

## Test 1 - Set self hosted false - no 'ping' expected

```bash
ubuntu@test:~$ HEALTHCHECKS_SELF_HOSTED=false
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

## Test 2 - leave self hosted unset - 'ping' expected

```bash
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/ping/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

## Test 3 - Set self hosted true - 'ping' expected

```bash
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
HEALTHCHECKS_SELF_HOSTED=true
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/ping/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

## Test 4 - Set self hosted true with custom subdir - 'CUSTOM' expected

```bash
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
HEALTHCHECKS_SELF_HOSTED=true
ubuntu@test:~$ HEALTHCHECKS_PING_ENDPOINT_DIR=CUSTOM
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/CUSTOM/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

## Test 5 - Set self hosted false with custom subdir - no 'CUSTOM' expected

```bash
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
HEALTHCHECKS_SELF_HOSTED=false
ubuntu@test:~$ HEALTHCHECKS_PING_ENDPOINT_DIR=CUSTOM
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

## Test 6 - Leave self hosted unset with custom subdir - 'CUSTOM' expected

```bash
ubuntu@test:~$ HEALTHCHECKSUUID=aa7b0de3-2c17-4fce-b051-388a5415e656
HEALTHCHECKSHOSTNAME=https://healthchecks.mydomain.com
ubuntu@test:~$ HEALTHCHECKS_PING_ENDPOINT_DIR=CUSTOM
ubuntu@test:~$ # Default to self-hosted if variable is unset
HEALTHCHECKS_SELF_HOSTED="${HEALTHCHECKS_SELF_HOSTED:-true}" # Defaults to 'true' if unset.

# Set the ping subdirectory for self-hosted instances only
if [[ "${HEALTHCHECKS_SELF_HOSTED}" == "true" ]]; then
    PING_SUBDIR="${HEALTHCHECKS_PING_ENDPOINT_DIR:-ping}" # Defaults to 'ping' if unset.
else
    PING_SUBDIR=""
fi

# Construct Healthchecks URL if required variables are set
if [[ -n "${HEALTHCHECKSHOSTNAME// }" && -n "${HEALTHCHECKSUUID// }" ]]; then
    if [[ -n "$PING_SUBDIR" ]]; then
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${PING_SUBDIR}/${HEALTHCHECKSUUID}"
    else
        HEALTHCHECKSURL="${HEALTHCHECKSHOSTNAME}/${HEALTHCHECKSUUID}"
    fi
    export HEALTHCHECKSURL
fi
ubuntu@test:~$ echo $HEALTHCHECKSURL
https://healthchecks.mydomain.com/CUSTOM/aa7b0de3-2c17-4fce-b051-388a5415e656 ## As expected
```

LGTM, merging when checks pass.


