### PR TITLE
Set /tmp as a mount 

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -8,12 +8,16 @@ services:
     env_file:
       - .env
     tmpfs:
-      - /tmp
       - /run:exec
     volumes:
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 1073741824
       - ./pbsconfig/:/root/.config/proxmox-backup/
       # Note - if you want to restore backups make sure to change to read write below.
       # See the 'restore-backup' command inside the container.
       - ./backups/test1:/backups/test1:ro
       - ./backups/test2:/backups/test2:ro
       - ./backups/test3:/backups/test3:ro
+


### PR DESCRIPTION
Avoids:

Error downloading .didx from previous manifest: Operation not supported (os error 95).