### PR TITLE
Set ulimit for file and user limits in backup script

### DIFF
--- a/docker/src/s6-services/cron-backup/run
+++ b/docker/src/s6-services/cron-backup/run
@@ -2,6 +2,9 @@
 # shellcheck shell=bash
 # This script instates the cron job to take regular backups.
 
+# Raise limits before running PBS
+ulimit -n 65536
+ulimit -u 65536
 
 # Define a logging function to prefix output to the docker logs.
 output_to_log() {


### PR DESCRIPTION
Increase file and user limits for backup script execution.

Possibly addresses: https://github.com/Aterfax/pbs-client-docker/issues/34#issuecomment-3932548299