### PR TITLE
Fix high CPU caused by nullmailer trigger file being present instead of allowing creation of named pipe

### DIFF
--- a/docker/src/s6-services/nullmailer-configure/run
+++ b/docker/src/s6-services/nullmailer-configure/run
@@ -74,4 +74,9 @@ mkdir -p /var/spool/nullmailer/tmp
 chmod 750 /var/spool/nullmailer
 chmod 700 /var/spool/nullmailer/{queue,tmp}
 
+# Ensure any non-pipe trigger files are removed prior to service start
+if [ ! -p /var/spool/nullmailer/trigger ]; then
+    rm -f /var/spool/nullmailer/trigger
+fi 
+
 echo "nullmailer configured."

--- a/docker/src/s6-services/nullmailer-configure/run
+++ b/docker/src/s6-services/nullmailer-configure/run
@@ -69,12 +69,9 @@ hostname >/etc/mailname
 mkdir -p /var/spool/nullmailer/queue
 mkdir -p /var/spool/nullmailer/tmp
 
-touch /var/spool/nullmailer/trigger
-
 # nullmailer must own its spool
 #chown -R nullmail:nullmail /var/spool/nullmailer # Not needed since we run service as root.
 chmod 750 /var/spool/nullmailer
 chmod 700 /var/spool/nullmailer/{queue,tmp}
-chmod 600 /var/spool/nullmailer/trigger
 
 echo "nullmailer configured."


### PR DESCRIPTION
Removed unnecessary touch and chmod for trigger file.

See issue https://github.com/Aterfax/pbs-client-docker/issues/66

Nullmailer should create its own trigger pipe during start.

https://sources.debian.org/src/nullmailer/1%3A2.2%2B10~g7ed88a0-6.1/debian/nullmailer.init/#L29-L32