### PR TITLE
Create /var/spool/nullmailer/trigger

### DIFF
--- a/docker/src/s6-services/nullmailer-configure/run
+++ b/docker/src/s6-services/nullmailer-configure/run
@@ -77,6 +77,7 @@ chmod 700 /var/spool/nullmailer/{queue,tmp}
 # Ensure any non-pipe trigger files are removed prior to service start
 if [ ! -p /var/spool/nullmailer/trigger ]; then
     rm -f /var/spool/nullmailer/trigger
+    mkfifo /var/spool/nullmailer/trigger
 fi 
 
 echo "nullmailer configured."


### PR DESCRIPTION
Unfortunately, PR #70 introduced a regression by removing the trigger file, which is required to trigger nullmailer-send and have mails sent